### PR TITLE
Add *AUTO-ESCAPE*

### DIFF
--- a/src/package.lisp
+++ b/src/package.lisp
@@ -9,4 +9,5 @@
            :escape-string :raw :esc
            :enable-markup-syntax
            :*output-stream*
+	   :*auto-escape*
            :*markup-language*))

--- a/src/util.lisp
+++ b/src/util.lisp
@@ -1,5 +1,7 @@
 (in-package :cl-markup)
 
+(defvar *auto-escape* t)
+
 (defun map-group-if (pred list fn)
   (loop
     while list
@@ -37,16 +39,18 @@
         string)))
 
 (defun escape-string (string)
-  (substitute-string-by
-   (lambda (char)
-     (case char
-       (#\& "&amp;")
-       (#\< "&lt;")
-       (#\> "&gt;")
-       (#\' "&#039;")
-       (#\" "&quot;")
-       (t (string char))))
-   string))
+  (if *auto-escape*
+      (substitute-string-by
+       (lambda (char)
+	 (case char
+	   (#\& "&amp;")
+	   (#\< "&lt;")
+	   (#\> "&gt;")
+	   (#\' "&#039;")
+	   (#\" "&quot;")
+	   (t (string char))))
+       string)
+      string))
 
 (defun ensure-string (val)
   (if (stringp val)


### PR DESCRIPTION
While mentioned in the README, the parameter `*AUTO-ESCAPE*` did not exist. This adds that parameter, although imperfectly. Since it needs to be bound when macro is expanded, the example from README is
still incorrect.
